### PR TITLE
Add useScaffoldEventRead hook and show withdraw events

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,9 +30,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Run hardhat node, deploy contracts (& generate contracts typescript output)
-        run: yarn chain & yarn deploy 
-
       - name: Run nextjs lint
         run: yarn next:lint --max-warnings=0
 

--- a/packages/nextjs/hooks/scaffold-eth/index.ts
+++ b/packages/nextjs/hooks/scaffold-eth/index.ts
@@ -9,4 +9,5 @@ export * from "./useOutsideClick";
 export * from "./useScaffoldContractRead";
 export * from "./useScaffoldContractWrite";
 export * from "./useScaffoldEventSubscriber";
+export * from "./useScaffoldEventRead";
 export * from "./useTransactor";

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventRead.ts
@@ -1,0 +1,124 @@
+import { ContractAbi, ContractName } from "./contract.types";
+import { ExtractAbiEventNames } from "abitype";
+import { useProvider, useContract } from "wagmi";
+import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
+import { ethers } from "ethers";
+import { useEffect, useState } from 'react';
+
+/**
+ * @dev reads events from a deployed contract
+ * @param config - The config settings
+ * @param config.contractName - deployed contract name
+ * @param config.eventName - name of the event to listen for
+ * @param config.fromBlock - the block number to start reading events from (default: 1000 blocks before current block)
+ * @param config.filters - filters to be applied to the event (parameterName: value)
+ * @param config.blockData - if set to true it will return the block data for each event (default: false)
+ * @param config.transactionData - if set to true it will return the transaction data for each event (default: false)
+ * @param config.receiptData - if set to true it will return the receipt data for each event (default: false)
+ */
+export const useScaffoldEventRead = <
+  TContractName extends ContractName,
+  TEventName extends ExtractAbiEventNames<ContractAbi<TContractName>>,
+>({
+  contractName,
+  eventName,
+  fromBlock,
+  filters,
+  blockData,
+  transactionData,
+  receiptData,
+}: {
+  contractName: TContractName;
+  eventName: TEventName;
+  fromBlock?: number;
+  filters?: any;
+  blockData?: boolean;
+  transactionData?: boolean;
+  receiptData?: boolean;
+}) => {
+  const [events, setEvents] = useState(<any>[]);
+  const { data: deployedContractData } = useDeployedContractInfo(contractName);
+  const provider = useProvider();
+
+  const contract = useContract({
+    address: deployedContractData?.address,
+    abi: deployedContractData?.abi,
+    signerOrProvider: provider,
+  });
+
+  useEffect(() => {
+    async function readEvents() {
+      if (!contract) {
+        console.log("contract not found");
+        return;
+      }
+      try {
+        if (!fromBlock) {
+          fromBlock = await provider.getBlockNumber() - 1000;
+        }
+
+        const fragment = contract.interface.getEvent(eventName);
+        if (!fragment) {
+          console.log("event not found");
+          return;
+        }
+
+        const emptyIface = new ethers.utils.Interface([])
+        const topicHash = emptyIface.getEventTopic(fragment)
+        const topics = <any>[ topicHash ];
+
+        const indexedParameters = fragment.inputs.filter((input) => input.indexed);
+
+        if (indexedParameters.length > 0 && filters) {
+          const indexedTopics = indexedParameters.map((input) => {
+            const value = filters[input.name];
+            if (value === undefined) {
+              return null;
+            }
+            if (Array.isArray(value)) {
+              return value.map((v) => ethers.utils.hexZeroPad(ethers.utils.hexlify(v), 32));
+            }
+            return ethers.utils.hexZeroPad(ethers.utils.hexlify(value), 32);
+          });
+          topics.push(...indexedTopics);
+        }
+
+        const logs = await provider.getLogs({
+            address: deployedContractData?.address,
+            topics: topics,
+            fromBlock: fromBlock,
+        });
+        const newEvents = [];
+        for (let i=0; i<logs.length; i++) {
+          let block;
+          if (blockData) {
+            block = await provider.getBlock(logs[i].blockHash);
+          }
+          let transaction;
+          if (transactionData) {
+            transaction = await provider.getTransaction(logs[i].transactionHash);
+          }
+          let receipt;
+          if (receiptData) {
+            receipt = await provider.getTransactionReceipt(logs[i].transactionHash);
+          }
+          const log = {
+            log: logs[i],
+            args: contract.interface.parseLog(logs[i]).args,
+            block: block,
+            transaction: transaction,
+            receipt: receipt,
+          }
+          newEvents.push(log);
+        }
+        setEvents(newEvents.reverse());
+      }
+      catch (e) {
+          console.log(e);
+      }
+    }
+    readEvents();
+  }, [provider, fromBlock, contractName, eventName, deployedContractData?.address, contract]);
+
+  return events;
+};

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -151,8 +151,8 @@ const Home: NextPage = () => {
           {/* dummy input to capture event onclick on modal box */}
           <input className="h-0 w-0 absolute top-0 left-0" />
           <h3 className="text-xl font-bold mb-8">
+            <p className="mb-1">Work History</p>
             <Address address={selectedAddress} />
-            Withdraw History
           </h3>
           <label htmlFor="withdraw-events-modal" className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">
             ✕
@@ -160,26 +160,24 @@ const Home: NextPage = () => {
           <div className="space-y-3">
             <ul>
               {filteredEvents.length > 0 ? (
-                <table className="border-collapse table-auto w-full text-sm">
-                  <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Reason</th>
-                      <th>Amount</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {filteredEvents.map(event => (
-                      <tr key={event.log.transactionHash}>
-                        <td>{new Date(event.block.timestamp).toISOString().split("T")[0]}</td>
-                        <td>{event.args.reason}</td>
-                        <td className="text-right">Ξ {ethers.utils.formatEther(event.args.amount.toString())}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <div className="flex flex-col">
+                  {filteredEvents.map(event => (
+                    <div key={event.log.transactionHash} className="flex flex-col">
+                      <div>
+                        <span className="font-bold">Date: </span>
+                        {new Date(event.block.timestamp).toISOString().split("T")[0]}
+                      </div>
+                      <div>
+                        <span className="font-bold">Amount: </span>Ξ{" "}
+                        {ethers.utils.formatEther(event.args.amount.toString())}
+                      </div>
+                      <div>{event.args.reason}</div>
+                      <hr className="my-8" />
+                    </div>
+                  ))}
+                </div>
               ) : (
-                <p>No withdraws</p>
+                <p>No work history</p>
               )}
             </ul>
           </div>

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -42,7 +42,7 @@ const Home: NextPage = () => {
   const events = useScaffoldEventRead({
     contractName: "YourContract",
     eventName: "Withdraw",
-    fromBlock: 0,
+    fromBlock: Number(process.env.NEXT_PUBLIC_DEPLOY_BLOCK) || 0,
     blockData: true,
   });
 


### PR DESCRIPTION
useScaffoldEventRead hook allows to get the events from a contract.

Only contractName and eventName are mandatory.

You can choose if you want to get the block, transaction or receipt data with the blockData, transactionData and receiptData flags. Default to false to avoid RPC calls.

fromBlock default value is set to 1000 blocks before the current block. If you want to get all the events from the contract, set it to the block number when the contract was deployed.

Use filters to filters the events by the indexed parameters.

Example usage:

```
  const events = useScaffoldEventRead({
    contractName: "YourContract",
    eventName: "Withdraw",
    fromBlock: 0,
    blockData: true,
    transactionData: true,
    receiptData: true,
    filters: {
    	to: "0x5dCb5f4F39Caa6Ca25380cfc42280330b49d3c93",
    }
  });
```