### PR TITLE
Hide Withdraw button at index

### DIFF
--- a/packages/nextjs/components/StreamContractInfo.tsx
+++ b/packages/nextjs/components/StreamContractInfo.tsx
@@ -5,7 +5,7 @@ import { BanknotesIcon, QuestionMarkCircleIcon } from "@heroicons/react/24/outli
 import { Address, Balance } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 
-export const StreamContractInfo = () => {
+export const StreamContractInfo = ({ showWithdrawButton = true }) => {
   const { address } = useAccount();
   const { data: streamContract } = useDeployedContractInfo("YourContract");
 
@@ -44,7 +44,7 @@ export const StreamContractInfo = () => {
           /
           <Balance address={streamContract?.address} className="text-3xl" />
         </div>
-        {address && amIAStreamdBuilder && (
+        {showWithdrawButton && address && amIAStreamdBuilder && (
           <div className="mt-3">
             <label
               htmlFor="withdraw-modal"

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -37,7 +37,7 @@ const Home: NextPage = () => {
           </p>
         </div>
         <div className="mb-10">
-          <StreamContractInfo />
+          <StreamContractInfo showWithdrawButton={false} />
         </div>
       </div>
     </>


### PR DESCRIPTION
No big deal since is shown only for builders of Sand Garden, but maybe it's better to just show it in Members tab. 
Replicate Withdraw click handler at index would be a bit overkill, so probably hiding may be the way to go.